### PR TITLE
v0.3.2: Platform compatibility fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,6 +288,7 @@ jobs:
 
         ./sxc-macos-${{ matrix.arch }} test_hello.sx
         clang -O2 \
+          -I$OPENSSL_PREFIX/include -I$SQLITE_PREFIX/include \
           -L$OPENSSL_PREFIX/lib -L$SQLITE_PREFIX/lib \
           test_hello.ll runtime/standalone_runtime.c \
           -o test_hello -lm -lssl -lcrypto -lsqlite3


### PR DESCRIPTION
Changes:
- Added Linux epoll support (was macOS kqueue only)
- Fixed OpenSSL include paths in CI workflow

Version bumps:
| Tool    | Version |
|---------|---------|
| sxc     | v0.3.2  |
| cursus  | v0.1.1  |
| sxdoc   | v0.1.1  |
| sxlsp   | v0.1.1  |