### PR TITLE
Fix Linux support: fix llc path, target triple, linker flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.bak
+build/
+*.o
+*.ll
+hello
+hello.sx

--- a/compiler/bootstrap/codegen.sx
+++ b/compiler/bootstrap/codegen.sx
@@ -4323,7 +4323,7 @@ fn gen_item(cg: i64, item: i64) -> i64 {
 // Generate program header
 fn gen_header(cg: i64) -> i64 {
     emit_line(cg, "; ModuleID = 'simplex_program'");
-    emit_line(cg, "target triple = \"x86_64-apple-macosx14.0.0\"");
+    emit_line(cg, "target triple = \"x86_64-pc-linux-gnu\"");
     emit_line(cg, "");
     emit_line(cg, "declare ptr @malloc(i64)");
     emit_line(cg, "declare void @free(ptr)");

--- a/compiler/bootstrap/main.sx
+++ b/compiler/bootstrap/main.sx
@@ -514,7 +514,7 @@ fn compile_file_force(path: i64, output_path: i64, verbose: i64, emit_type: i64,
             asm_path = string_replace_ext(path, ".s");
         }
         // Run: llc -o <asm_path> <ll_path>
-        let cmd: i64 = string_concat(string_from("/usr/local/opt/llvm/bin/llc -o "), asm_path);
+        let cmd: i64 = string_concat(string_from("/usr/bin/llc -o "), asm_path);
         cmd = string_concat(cmd, string_from(" "));
         cmd = string_concat(cmd, ll_path);
         let result: i64 = process_run(cmd);
@@ -535,7 +535,7 @@ fn compile_file_force(path: i64, output_path: i64, verbose: i64, emit_type: i64,
             obj_path = string_replace_ext(path, ".o");
         }
         // Run: llc -filetype=obj -o <obj_path> <ll_path>
-        let cmd: i64 = string_concat(string_from("/usr/local/opt/llvm/bin/llc -filetype=obj -o "), obj_path);
+        let cmd: i64 = string_concat(string_from("/usr/bin/llc -filetype=obj -o "), obj_path);
         cmd = string_concat(cmd, string_from(" "));
         cmd = string_concat(cmd, ll_path);
         let result: i64 = process_run(cmd);
@@ -558,7 +558,7 @@ fn compile_file_force(path: i64, output_path: i64, verbose: i64, emit_type: i64,
         }
         // First compile to object
         let obj_path: i64 = string_replace_ext(path, ".o");
-        let cmd: i64 = string_concat(string_from("/usr/local/opt/llvm/bin/llc -filetype=obj -o "), obj_path);
+        let cmd: i64 = string_concat(string_from("/usr/bin/llc -filetype=obj -o "), obj_path);
         cmd = string_concat(cmd, string_from(" "));
         cmd = string_concat(cmd, ll_path);
         let result: i64 = process_run(cmd);
@@ -567,10 +567,10 @@ fn compile_file_force(path: i64, output_path: i64, verbose: i64, emit_type: i64,
             return 1;
         }
         // Then link with clang
-        cmd = string_concat(string_from("clang -o "), exe_path);
+        cmd = string_concat(string_from("clang -no-pie -o "), exe_path);
         cmd = string_concat(cmd, string_from(" "));
         cmd = string_concat(cmd, obj_path);
-        cmd = string_concat(cmd, string_from(" standalone_runtime.o"));
+        cmd = string_concat(cmd, string_from(" standalone_runtime.o -lm -lssl -lcrypto -lsqlite3 -lpthread"));
         result = process_run(cmd);
         if result != 0 {
             println(string_from("Error: linking failed"));
@@ -590,7 +590,7 @@ fn compile_file_force(path: i64, output_path: i64, verbose: i64, emit_type: i64,
         }
         // First compile to object with PIC (position-independent code)
         let obj_path: i64 = string_replace_ext(path, ".o");
-        let cmd: i64 = string_concat(string_from("/usr/local/opt/llvm/bin/llc -filetype=obj -relocation-model=pic -o "), obj_path);
+        let cmd: i64 = string_concat(string_from("/usr/bin/llc -filetype=obj -relocation-model=pic -o "), obj_path);
         cmd = string_concat(cmd, string_from(" "));
         cmd = string_concat(cmd, ll_path);
         let result: i64 = process_run(cmd);

--- a/compiler/bootstrap/merge.sx
+++ b/compiler/bootstrap/merge.sx
@@ -428,7 +428,7 @@ fn replace_string_labels(state: i64) -> i64 {
 // Write output file
 fn write_output(state: i64, output_path: i64) -> i64 {
     let result: i64 = string_from("; ModuleID = \"simplex_program\"\n");
-    result = string_concat(result, "target triple = \"x86_64-apple-macosx14.0.0\"\n\n");
+    result = string_concat(result, "target triple = \"x86_64-pc-linux-gnu\"\n\n");
 
     // Write declarations (sorted would be nice but not critical)
     let decls: i64 = merge_declarations(state);

--- a/compiler/bootstrap/stage0.py
+++ b/compiler/bootstrap/stage0.py
@@ -2412,7 +2412,7 @@ class CodeGen:
     def generate(self, items):
         # Header
         self.emit('; ModuleID = "simplex_program"')
-        self.emit('target triple = "x86_64-apple-macosx15.0.0"')
+        self.emit('target triple = "x86_64-pc-linux-gnu"')
         self.emit('')
 
         # External declarations

--- a/stage0.py
+++ b/stage0.py
@@ -2412,7 +2412,7 @@ class CodeGen:
     def generate(self, items):
         # Header
         self.emit('; ModuleID = "simplex_program"')
-        self.emit('target triple = "x86_64-apple-macosx15.0.0"')
+        self.emit('target triple = "x86_64-pc-linux-gnu"')
         self.emit('')
 
         # External declarations

--- a/tools/compiler.sx
+++ b/tools/compiler.sx
@@ -1552,7 +1552,7 @@ fn gen_item(cg: i64, item: i64) -> i64 {
 // Generate program header
 fn gen_header(cg: i64) -> i64 {
     emit_line(cg, "; ModuleID = 'simplex_program'");
-    emit_line(cg, "target triple = \"x86_64-apple-macosx14.0.0\"");
+    emit_line(cg, "target triple = \"x86_64-pc-linux-gnu\"");
     emit_line(cg, "");
     emit_line(cg, "declare ptr @malloc(i64)");
     emit_line(cg, "declare void @intrinsic_println(ptr)");


### PR DESCRIPTION
1. LLVM llc path Changed the hardcoded path from /usr/local/opt/llvm/bin/llc (macOS Homebrew) to /usr/bin/llc (standard Linux location).
2. Target triple Changed x86_64-apple-macosx14.0.0 and x86_64-apple-macosx15.0.0 to x86_64-pc-linux-gnu so that llc generates ELF object files instead of Mach-O.
3. Linker flags
Added -no-pie to fix position-independent code relocation errors
Added -lm -lssl -lcrypto -lsqlite3 -lpthread to link the required libraries (math, OpenSSL, SQLite, pthreads)
Files modified:
compiler/bootstrap/main.sx
compiler/bootstrap/sxc_combined.ll
compiler/bootstrap/codegen.sx
compiler/bootstrap/merge.sx
compiler/bootstrap/stage0.py
tools/compiler.sx
stage0.py